### PR TITLE
Fix DNS AF version picker

### DIFF
--- a/pkg/dns.go
+++ b/pkg/dns.go
@@ -120,7 +120,7 @@ func processQuestion(c *Config, l zerolog.Logger, q dns.Question, decision acl.D
 // version specifies the IP version to lookup, 4 or 6. If 0, any version is picked.
 func (dnsc DNSClient) lookupDomain(domain string, version uint) (netip.Addr, error) {
 	if version == 0 {
-		version = uint(rand.Intn(2) + 4)
+		version = uint(rand.Intn(2)*2 + 4)
 	}
 	if version == 4 {
 		return dnsc.lookupDomain4(domain)


### PR DESCRIPTION
This line is intended to generate 4 or 6, but it generates 4 or 5.  
This bug causes random "invalid version" errors.