### PR TITLE
Check before dereferencing dnsc res.Answer

### DIFF
--- a/pkg/dns.go
+++ b/pkg/dns.go
@@ -71,6 +71,9 @@ func (dnsc *DNSClient) PerformExternalAQuery(fqdn string, QType uint16) ([]dns.R
 	}
 	res, err := dnsc.Resolve(&msg, rdns.ClientInfo{})
 	dnsLock.Unlock()
+	if res == nil {
+		return nil, err
+	}
 	return res.Answer, err
 }
 


### PR DESCRIPTION
In some cases, `res` is `nil` which causes panic while returning `res.Answer`. This will make sure `res` is not `nil`.