### PR TITLE
fix(acl): validate refresh_interval before starting refresh workers

### DIFF
--- a/pkg/acl/cidr.go
+++ b/pkg/acl/cidr.go
@@ -167,6 +167,9 @@ func (d *cidr) ConfigAndStart(logger *zerolog.Logger, c *koanf.Koanf) error {
 	d.Path = c.String("path")
 	d.priority = uint(c.Int("priority")) //nolint:gosec // G115 - priority is a small non-negative config value
 	d.RefreshInterval = c.Duration("refresh_interval")
+	if d.RefreshInterval <= 0 {
+		return fmt.Errorf("acl.cidr.refresh_interval must be a positive duration, got %v", d.RefreshInterval)
+	}
 	d.stopCh = make(chan struct{})
 	d.doneCh = make(chan struct{})
 	go d.loadCIDRCSVWorker(d.Path, d.RefreshInterval)

--- a/pkg/acl/domain.go
+++ b/pkg/acl/domain.go
@@ -202,6 +202,9 @@ func (d *domain) ConfigAndStart(logger *zerolog.Logger, c *koanf.Koanf) error {
 	d.Path = c.String("path")
 	d.priority = uint(c.Int("priority")) //nolint:gosec // G115 - priority is a small non-negative config value
 	d.RefreshInterval = c.Duration("refresh_interval")
+	if d.RefreshInterval <= 0 {
+		return fmt.Errorf("acl.domain.refresh_interval must be a positive duration, got %v", d.RefreshInterval)
+	}
 	d.stopCh = make(chan struct{})
 	d.doneCh = make(chan struct{})
 	go d.LoadDomainsCSVWorker(d.Path, d.RefreshInterval)

--- a/pkg/acl/geoip.go
+++ b/pkg/acl/geoip.go
@@ -197,6 +197,9 @@ func (g *geoIP) ConfigAndStart(logger *zerolog.Logger, c *koanf.Koanf) error {
 	g.AllowedCountries = toLowerSlice(c.Strings("allowed"))
 	g.BlockedCountries = toLowerSlice(c.Strings("blocked"))
 	g.Refresh = c.Duration("refresh_interval")
+	if g.Refresh <= 0 {
+		return fmt.Errorf("acl.geoip.refresh_interval must be a positive duration, got %v", g.Refresh)
+	}
 	g.stopCh = make(chan struct{})
 	g.doneCh = make(chan struct{})
 	go func() {

--- a/pkg/acl/refresh_interval_test.go
+++ b/pkg/acl/refresh_interval_test.go
@@ -1,0 +1,101 @@
+package acl
+
+import (
+	"os"
+	"testing"
+
+	"github.com/knadh/koanf"
+	"github.com/knadh/koanf/parsers/yaml"
+	"github.com/knadh/koanf/providers/rawbytes"
+	"github.com/rs/zerolog"
+)
+
+var reproLogger = zerolog.New(os.Stderr)
+
+// TestConfigAndStartRejectsZeroRefreshInterval guards against the
+// time.NewTicker panic: ConfigAndStart must reject a non-positive
+// refresh_interval instead of spawning a refresh goroutine that calls
+// time.NewTicker(0) (which panics and crashes the whole process).
+func TestConfigAndStartRejectsZeroRefreshInterval(t *testing.T) {
+	load := func(yamlDoc string) *koanf.Koanf {
+		k := koanf.New(".")
+		if err := k.Load(rawbytes.Provider([]byte(yamlDoc)), yaml.Parser()); err != nil {
+			t.Fatalf("koanf load: %v", err)
+		}
+		return k
+	}
+
+	cases := []struct {
+		name string
+		acl  ACL
+		doc  string
+	}{
+		{
+			name: "cidr",
+			acl:  &cidr{},
+			doc: `
+acl:
+  cidr:
+    enabled: true
+    priority: 30
+    path: ../../cidr.csv
+    refresh_interval: 0
+`,
+		},
+		{
+			name: "domain",
+			acl:  &domain{},
+			doc: `
+acl:
+  domain:
+    enabled: true
+    priority: 20
+    path: ../../domains.csv
+    refresh_interval: 0
+`,
+		},
+		{
+			name: "geoip",
+			acl:  &geoIP{},
+			doc: `
+acl:
+  geoip:
+    enabled: true
+    priority: 10
+    path: ../../GeoLite2-Country.mmdb
+    refresh_interval: 0
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.acl.ConfigAndStart(&reproLogger, load(tc.doc))
+			if err == nil {
+				t.Fatal("ConfigAndStart returned nil error for zero refresh_interval; expected rejection")
+			}
+		})
+	}
+}
+
+// TestConfigAndStartAcceptsPositiveRefreshInterval ensures the validation
+// does not break the normal configuration path.
+func TestConfigAndStartAcceptsPositiveRefreshInterval(t *testing.T) {
+	k := koanf.New(".")
+	if err := k.Load(rawbytes.Provider([]byte(`
+acl:
+  cidr:
+    enabled: true
+    priority: 30
+    path: ../../cidr.csv
+    refresh_interval: 1h0m0s
+`)), yaml.Parser()); err != nil {
+		t.Fatalf("koanf load: %v", err)
+	}
+
+	d := &cidr{}
+	if err := d.ConfigAndStart(&reproLogger, k); err != nil {
+		t.Fatalf("ConfigAndStart rejected valid config: %v", err)
+	}
+	d.Stop()
+}


### PR DESCRIPTION
## What

Validate `refresh_interval` in all three ACL `ConfigAndStart` implementations before spawning the refresh goroutine.

- `pkg/acl/cidr.go` — `ConfigAndStart`
- `pkg/acl/domain.go` — `ConfigAndStart`
- `pkg/acl/geoip.go` — `ConfigAndStart`

Each now rejects a non-positive `refresh_interval` with a descriptive error instead of silently starting a worker that calls `time.NewTicker(interval)`.

## Why

`time.NewTicker` panics on any non-positive duration (Go stdlib contract, `time/tick.go`). In the current code the panic fires inside the spawned refresh goroutine, which is unrecoverable — the whole process crashes.

Reproduction (verified at runtime before this fix):

```yaml
acl:
  cidr:
    enabled: true
    priority: 30
    path: /tmp/cidr.csv
    refresh_interval: 0
```

`ConfigAndStart` returned `nil` (no validation), then the worker goroutine panicked:

```
panic: non-positive interval for NewTicker

goroutine 9 [running]:
time.NewTicker(0x...)
	.../time/tick.go:38
github.com/mosajjal/sniproxy/v2/pkg/acl.(*cidr).loadCIDRCSVWorker(...)
	.../pkg/acl/cidr.go:112
created by ...(*cidr).ConfigAndStart
	.../pkg/acl/cidr.go:172
```

Control experiment after the fix: same config now returns `acl.cidr.refresh_interval must be a positive duration, got 0s` from `ConfigAndStart`, the worker is never started, and no panic occurs.

## How

Each `ConfigAndStart` now validates the parsed duration before creating `stopCh`/`doneCh` and starting the goroutine:

```go
d.RefreshInterval = c.Duration("refresh_interval")
if d.RefreshInterval <= 0 {
    return fmt.Errorf("acl.cidr.refresh_interval must be a positive duration, got %v", d.RefreshInterval)
}
```

## Tests

- New `TestConfigAndStartRejectsZeroRefreshInterval` covers cidr, domain, and geoip: zero `refresh_interval` → `ConfigAndStart` returns an error.
- New `TestConfigAndStartAcceptsPositiveRefreshInterval` ensures the valid config path still works.
- Existing `TestMakeDecision` suite passes unchanged.

```
go build ./...       ✓
go vet ./pkg/acl/    ✓
go test ./pkg/acl/   ✓
```

## Cache-impact

No cache impact — this is a configuration validation change at ACL startup.

---

*Discovered by [SmartBench](https://github.com/xianyu-sheng/SmartBench)* — deterministic scan (SemanticIR + resource-lifecycle rules) combined with evidence-gated multi-agent debate (Proposer → Critique → Judge), then verified at runtime: reproduced the `time.NewTicker` panic, applied the fix as a control experiment, and confirmed the panic disappears.
