### PR TITLE
Add goroutine leak profiling options

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [master]
 
+# goroutineleakprofile exposes the runtime's goroutine leak profile, and jsonv2
+# swaps encoding/json for the v2 implementation. Both are opt-in experiments in
+# Go 1.26 and become the default in 1.27. Set at job level so build, test and
+# lint all see the same toolchain configuration.
+env:
+  GOEXPERIMENT: goroutineleakprofile,jsonv2
+
 jobs:
 
   build:
@@ -16,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: 'stable'
+        go-version: '1.26'
 
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v8
@@ -29,5 +36,8 @@ jobs:
     - name: Test
       run: go test -v -race ./...
 
+    # run without -race: the race detector adds its own goroutines and slows
+    # detection down considerably. GOEXPERIMENT comes from the job env above;
+    # without it these tests skip rather than fail.
     - name: Goroutine leak detection
-      run: GOEXPERIMENT=goroutineleakprofile go test -v -run "Goroutine" ./...
+      run: go test -v -count=1 -run "Leak" ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
       - uses: wangyoucao577/go-release-action@master
         env:
           CGO_ENABLED: 0 # support alpine
+          # opt-in Go 1.26 experiments: runtime goroutine leak profile, and the
+          # v2 encoding/json implementation. Both are default-on in Go 1.27.
+          GOEXPERIMENT: goroutineleakprofile,jsonv2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ go build -v ./cmd/sniproxy/
 go test -v ./...
 ```
 
-Needs Go 1.24+ and git.
+Needs Go 1.26+ and git.
 
 ## Making changes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} golang:alpine
+FROM --platform=${TARGETPLATFORM:-linux/amd64} golang:1.26-alpine
 LABEL maintainer="Ali Mosajjal <hi@n0p.me>"
 
 ARG TARGETPLATFORM
@@ -11,6 +11,9 @@ RUN mkdir /app
 ADD . /app/
 WORKDIR /app/cmd/sniproxy
 ENV CGO_ENABLED=0
+# opt-in Go 1.26 experiments: runtime goroutine leak profile, and the v2
+# encoding/json implementation. Both become the default in Go 1.27.
+ENV GOEXPERIMENT=goroutineleakprofile,jsonv2
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOFLAGS=-buildvcs=false go build -ldflags "-s -w -X main.version=$(git describe --tags) -X main.commit=$(git rev-parse HEAD)" -o sniproxy .
 CMD ["/app/cmd/sniproxy/sniproxy"]
 

--- a/README.md
+++ b/README.md
@@ -78,9 +78,57 @@ sniproxy [flags]
 Flags:
   -c, --config string   path to YAML configuration file
       --defaultconfig    write the default config yaml file to stdout
+      --prof string     write a profile on exit. one of: cpu, mem, block, mutex,
+                        trace, threadcreate, goroutine, goroutineleak, clock
   -h, --help            help for sniproxy
   -v, --version         show version info and exit
 ```
+
+## Profiling and goroutine leaks
+
+sniproxy builds on Go 1.26 with two opt-in experiments, both of which become the default in Go
+1.27:
+
+```bash
+GOEXPERIMENT=goroutineleakprofile,jsonv2 go build ./cmd/sniproxy
+```
+
+`goroutineleakprofile` turns on the runtime's goroutine leak profile. A goroutine counts as
+leaked when it is blocked on a channel, mutex or condition variable that is unreachable from
+anything that could still unblock it, so the runtime can prove it will never wake up.
+`jsonv2` swaps `encoding/json` for the v2 implementation; the DoH JSON responses are
+byte-identical either way.
+
+The release binaries and the container image are built with both. A plain `go install` is not,
+and there the leak options report that the profile is missing instead of failing to build.
+
+Three ways to use it, from cheapest to most invasive:
+
+**Live, over HTTP.** Set `bind_pprof` in the config and fetch the profile on demand:
+
+```bash
+curl 'http://127.0.0.1:6060/debug/pprof/goroutineleak?debug=1'   # readable stacks
+go tool pprof http://127.0.0.1:6060/debug/pprof/goroutineleak    # binary profile
+```
+
+The rest of the standard `/debug/pprof/` handlers are on the same listener. Anyone who can reach
+that port can read stack traces and start expensive profiles, so bind it to loopback.
+
+**As a metric.** Set `goroutine_leak_interval` (e.g. `15m`) and sniproxy checks periodically,
+publishing the count as the `goroutines.leaked` gauge and logging a warning when it is non-zero.
+On the Prometheus endpoint that shows up as `sniproxy_<public_ipv4>_goroutines_leaked`, following
+the same namespace/subsystem scheme as the other metrics. Each check forces a full GC, so keep the
+interval coarse.
+
+**On exit.** `sniproxy --prof goroutineleak` writes `goroutineleak.pprof` to the temp directory
+when the process shuts down.
+
+Detection is reachability based, so a goroutine parked on a primitive still reachable from a
+global, or from a running goroutine's locals, will not be reported even if nothing will ever
+signal it. In practice that means it catches abandoned per-connection goroutines well, and
+misses anything still wired to a long-lived registry. Fetching the profile is what runs
+detection; it forces a GC and briefly stops the world, so treat it as a diagnostic rather than
+something to poll aggressively.
 
 ## API docs
 

--- a/cmd/sniproxy/config.defaults.yaml
+++ b/cmd/sniproxy/config.defaults.yaml
@@ -34,6 +34,21 @@ general:
   bind_https_additional:
   # Enable prometheus endpoint on IP:PORT. example: 127.0.0.1:8080. Always exposes /metrics and only supports HTTP
   bind_prometheus:
+  # Enable the pprof debug endpoint on IP:PORT. example: 127.0.0.1:6060. empty disables it.
+  # exposes the standard /debug/pprof/ handlers, plus the goroutine leak profile at
+  # /debug/pprof/goroutineleak (add ?debug=1 for readable stacks). anyone who can reach this port can
+  # read stack traces and trigger expensive profiles, so bind it to loopback.
+  bind_pprof:
+  # Periodically run goroutine leak detection and publish the count as the goroutines.leaked
+  # gauge (sniproxy_<public_ipv4>_goroutines_leaked in prometheus), logging a warning when it is
+  # above zero.
+  # empty or 0s disables it. example: 15m
+  # every check forces a full GC, so keep this coarse. use bind_pprof to get the stacks.
+  #
+  # NOTE: the leak profile only exists if sniproxy was built with
+  # GOEXPERIMENT=goroutineleakprofile (the release binaries and container image are).
+  # without it sniproxy warns at startup and the leak options do nothing.
+  goroutine_leak_interval: 0s
   # Interface used for outbound TLS connections. uses OS prefered one if empty
   interface:
   # Preferred ip version for outgoing connections. choises: ipv4 (or 4), ipv6 (or 6), ipv4only, ipv6only, any. empty (or 0) means any.

--- a/cmd/sniproxy/main.go
+++ b/cmd/sniproxy/main.go
@@ -2,9 +2,11 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
+	nethttppprof "net/http/pprof"
 	"net/netip"
 	"os"
 	"os/signal"
@@ -51,6 +53,48 @@ var defaultConfig []byte
 var nocolorLog = strings.ToLower(os.Getenv("NO_COLOR")) == "true"
 var logger = zerolog.New(os.Stderr).With().Timestamp().Logger().Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339, NoColor: nocolorLog})
 
+// goroutineLeakProfiler writes a goroutineleak profile when sniproxy exits.
+// github.com/pkg/profile has no goroutineleak mode, so this reimplements the
+// same Stop() shape directly on top of runtime/pprof.
+type goroutineLeakProfiler struct {
+	path string
+}
+
+func (g *goroutineLeakProfiler) Stop() {
+	f, err := os.Create(g.path)
+	if err != nil {
+		logger.Error().Err(err).Msg("failed to create goroutine leak profile file")
+		return
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			logger.Error().Err(err).Msg("failed to close goroutine leak profile file")
+		}
+	}()
+
+	n, err := sniproxy.WriteGoroutineLeakProfile(f, 0)
+	if err != nil {
+		logger.Error().Err(err).Msg("failed to write goroutine leak profile")
+		return
+	}
+	logger.Info().Int("leaked", n).Msgf("goroutine leak profile written to %s", g.path)
+}
+
+// isLoopbackAddr reports whether a "host:port" bind address is restricted to
+// the loopback interface. An empty host means every interface, and a name other
+// than localhost could resolve anywhere, so both count as not loopback.
+func isLoopbackAddr(bind string) bool {
+	host, _, err := net.SplitHostPort(bind)
+	if err != nil {
+		return false
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip, err := netip.ParseAddr(host)
+	return err == nil && ip.IsLoopback()
+}
+
 func enableProfile(profileType string) interface{ Stop() } {
 	switch profileType {
 	case "":
@@ -69,6 +113,10 @@ func enableProfile(profileType string) interface{ Stop() } {
 		return profile.Start(profile.ThreadcreationProfile)
 	case "goroutine":
 		return profile.Start(profile.GoroutineProfile)
+	case "goroutineleak":
+		// on shutdown, run leak detection and dump the stacks of every
+		// goroutine that can never become runnable again
+		return &goroutineLeakProfiler{path: filepath.Join(os.TempDir(), "goroutineleak.pprof")}
 	case "clock":
 		return profile.Start(profile.ClockProfile)
 	default:
@@ -87,7 +135,7 @@ func main() {
 	flags := cmd.Flags()
 	config := flags.StringP("config", "c", "", "path to YAML configuration file")
 	_ = flags.Bool("defaultconfig", false, "write the default config yaml file to stdout")
-	prof := flags.String("prof", "", "enable profiling. can be one of: [cpu, mem, block, mutex, trace, threadcreate, goroutine, clock]")
+	prof := flags.String("prof", "", "enable profiling. can be one of: [cpu, mem, block, mutex, trace, threadcreate, goroutine, goroutineleak, clock]")
 	_ = flags.BoolP("version", "v", false, "show version info and exit")
 	if err := cmd.Execute(); err != nil {
 		logger.Error().Msgf("failed to execute command: %s", err)
@@ -203,6 +251,8 @@ func main() {
 	}
 
 	c.BindPrometheus = generalConfig.String("prometheus")
+	c.BindPprof = generalConfig.String("bind_pprof")
+	c.GoroutineLeakInterval = generalConfig.Duration("goroutine_leak_interval")
 	c.AllowConnToLocal = generalConfig.Bool("allow_conn_to_local")
 
 	// Validate configuration before proceeding
@@ -242,6 +292,59 @@ func main() {
 				logger.Error().Msgf("%s", err)
 			}
 		}()
+	}
+
+	// runtime context, canceled once a shutdown signal arrives
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Fail loudly at startup rather than at the first tick (the watcher) or at
+	// exit (--prof), which is where the missing profile would otherwise surface.
+	if (c.GoroutineLeakInterval > 0 || *prof == "goroutineleak") && !sniproxy.GoroutineLeakProfileAvailable() {
+		logger.Warn().Msgf(
+			"goroutine leak detection was requested, but this binary was built without it. rebuild with GOEXPERIMENT=%s",
+			sniproxy.GoroutineLeakExperiment,
+		)
+	}
+
+	// pprof server. this is deliberately a dedicated mux rather than the
+	// DefaultServeMux that importing net/http/pprof normally hijacks, so the
+	// debug handlers can never leak onto the metrics listener.
+	if c.BindPprof != "" {
+		if !isLoopbackAddr(c.BindPprof) {
+			logger.Warn().Msgf("pprof is bound to %s, which is not loopback. it exposes stack traces and lets anyone who can reach it trigger expensive profiles", c.BindPprof)
+		}
+
+		mux := http.NewServeMux()
+		// Index serves every named profile at /debug/pprof/<name>, which
+		// includes goroutineleak
+		mux.HandleFunc("/debug/pprof/", nethttppprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", nethttppprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", nethttppprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", nethttppprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", nethttppprof.Trace)
+
+		pprofServer := &http.Server{
+			Addr:    c.BindPprof,
+			Handler: mux,
+			// no write timeout on purpose: CPU and trace profiles stream for
+			// 30s or longer by default
+			ReadHeaderTimeout: 5 * time.Second,
+		}
+		logger.Info().Str("address", c.BindPprof).Msgf("starting pprof server. goroutine leaks: http://%s/debug/pprof/%s?debug=1", c.BindPprof, sniproxy.GoroutineLeakProfile)
+		go func() {
+			if err := pprofServer.ListenAndServe(); err != nil {
+				logger.Error().Msgf("%s", err)
+			}
+		}()
+	}
+
+	// periodic goroutine leak detection. off unless an interval is configured,
+	// because every check forces a full GC.
+	if c.GoroutineLeakInterval > 0 {
+		leaked := metrics.GetOrRegisterGauge("goroutines.leaked", metrics.DefaultRegistry)
+		logger.Info().Msgf("goroutine leak detection enabled, checking every %s", c.GoroutineLeakInterval)
+		go sniproxy.WatchGoroutineLeaks(ctx, c.GoroutineLeakInterval, leaked, logger)
 	}
 
 	// generate self-signed certificate if not provided.
@@ -324,6 +427,7 @@ func main() {
 
 	sig := <-sigChan
 	logger.Info().Msgf("received signal %v, shutting down gracefully...", sig)
+	cancel()
 
 	// Stop ACL refresh goroutines
 	acl.StopACLs(c.ACL)

--- a/cmd/sniproxy/main_test.go
+++ b/cmd/sniproxy/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import "testing"
+
+func TestIsLoopbackAddr(t *testing.T) {
+	for _, tc := range []struct {
+		bind string
+		want bool
+	}{
+		{"127.0.0.1:6060", true},
+		{"127.1.2.3:6060", true},
+		{"localhost:6060", true},
+		{"[::1]:6060", true},
+		{"0.0.0.0:6060", false},
+		{"[::]:6060", false},
+		{":6060", false}, // every interface
+		{"192.168.1.10:6060", false},
+		{"example.com:6060", false}, // could resolve anywhere
+		{"6060", false},             // not host:port at all
+		{"", false},
+	} {
+		if got := isLoopbackAddr(tc.bind); got != tc.want {
+			t.Errorf("isLoopbackAddr(%q) = %v, want %v", tc.bind, got, tc.want)
+		}
+	}
+}

--- a/pkg/conf.go
+++ b/pkg/conf.go
@@ -2,6 +2,7 @@ package sniproxy
 
 import (
 	"fmt"
+	"net"
 	"net/netip"
 	"net/url"
 	"strconv"
@@ -91,7 +92,12 @@ type Config struct {
 	BindHTTPSListeners    []string `yaml:"-"` // compiled list of bind_https and bind_https_additional listen addresses
 	Interface             string   `yaml:"interface"`
 	BindPrometheus        string   `yaml:"bind_prometheus"`
+	BindPprof             string   `yaml:"bind_pprof"`
 	AllowConnToLocal      bool     `yaml:"allow_conn_to_local"`
+
+	// GoroutineLeakInterval enables the periodic goroutine leak check when
+	// non-zero. Each check forces a full GC, so keep it coarse.
+	GoroutineLeakInterval time.Duration `yaml:"goroutine_leak_interval"`
 
 	ACL []acl.ACL `yaml:"-"`
 
@@ -149,6 +155,16 @@ func (c *Config) Validate() error {
 	// Validate TLS configuration if TLS/QUIC DNS is enabled
 	if (c.BindDNSOverTLS != "" || c.BindDNSOverQuic != "") && (c.TLSCert == "" || c.TLSKey == "") {
 		return fmt.Errorf("TLS certificate and key are required for DNS over TLS/QUIC")
+	}
+
+	if c.BindPprof != "" {
+		if _, _, err := net.SplitHostPort(c.BindPprof); err != nil {
+			return fmt.Errorf("bind_pprof must be a host:port address: %w", err)
+		}
+	}
+
+	if c.GoroutineLeakInterval < 0 {
+		return fmt.Errorf("goroutine_leak_interval must not be negative")
 	}
 
 	return nil

--- a/pkg/goroutineleak_test.go
+++ b/pkg/goroutineleak_test.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"io"
 	"net"
-	"runtime"
-	"runtime/pprof"
+	"slices"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -14,29 +15,123 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// checkGoroutineLeaks looks up the goroutineleak profile (available when built
-// with GOEXPERIMENT=goroutineleakprofile) and fails the test if any leaked
-// goroutines are detected. Skips gracefully when the experiment is not enabled.
+// requireLeakProfile skips the test unless the binary was built with
+// GOEXPERIMENT=goroutineleakprofile. A plain `go test ./...` does not set it,
+// so these checks only really run in the dedicated CI step.
+func requireLeakProfile(t *testing.T) {
+	t.Helper()
+	if !GoroutineLeakProfileAvailable() {
+		t.Skip("goroutineleak profile not compiled in; rebuild with GOEXPERIMENT=goroutineleakprofile")
+	}
+}
+
+// checkGoroutineLeaks fails the test if the runtime can prove any goroutine is
+// permanently blocked.
+//
+// Order matters here: writing the profile is what runs the leak-detecting GC
+// cycle. Profile.Count only reports the result of the most recent detection
+// run, so calling it first would read a stale count (zero, if nothing has ever
+// triggered detection) and quietly pass on a real leak.
 func checkGoroutineLeaks(t *testing.T) {
 	t.Helper()
+	requireLeakProfile(t)
 
-	// Give the GC a chance to identify unreachable primitives.
-	for range 5 {
-		runtime.GC()
-		time.Sleep(20 * time.Millisecond)
+	var buf bytes.Buffer
+	if _, err := WriteGoroutineLeakProfile(&buf, 1); err != nil {
+		t.Fatalf("goroutine leak detection failed: %v", err)
 	}
-
-	p := pprof.Lookup("goroutineleak")
-	if p == nil {
-		t.Skip("goroutineleak profile not available (build with GOEXPERIMENT=goroutineleakprofile)")
+	if n, stacks := unexpectedLeaks(buf.String()); n > 0 {
+		t.Errorf("%d leaked goroutine(s) detected:\n%s", n, stacks)
 	}
+}
 
-	if p.Count() > 0 {
-		var buf bytes.Buffer
-		if err := p.WriteTo(&buf, 1); err != nil {
-			t.Fatalf("failed to write goroutineleak profile: %v", err)
+// knownLeaks are leak sites these tests deliberately tolerate. Leaked
+// goroutines are never reclaimed, so anything listed here would otherwise fail
+// every check that runs after the leak is created.
+var knownLeaks = []string{
+	// routedns starts a Pipeline goroutine per DNS client which ranges over a
+	// request channel it never closes, and exposes no way to shut it down. So
+	// every rdns.NewDNSClient parks one goroutine for the life of the process.
+	// sniproxy builds its DNS client once at startup, which bounds this at one
+	// in production, but each NewDNSClient in a test adds another.
+	"routedns.(*Pipeline).start",
+	// planted on purpose by TestGoroutineLeakProfile_DetectsKnownLeak
+	"leakOneGoroutine",
+}
+
+// unexpectedLeaks parses a debug=1 goroutineleak profile and returns how many
+// leaked goroutines are not attributable to knownLeaks, along with their
+// stacks. The format is one record per distinct stack, separated by a blank
+// line, each starting with "<count> @ <pcs>".
+func unexpectedLeaks(profile string) (int, string) {
+	var (
+		total  int
+		stacks []string
+	)
+	for _, record := range strings.Split(profile, "\n\n") {
+		record = strings.TrimSpace(record)
+		if record == "" || strings.HasPrefix(record, "goroutineleak profile:") {
+			continue
 		}
-		t.Errorf("goroutine leaks detected:\n%s", buf.String())
+		if slices.ContainsFunc(knownLeaks, func(known string) bool {
+			return strings.Contains(record, known)
+		}) {
+			continue
+		}
+		count, _, ok := strings.Cut(record, " @ ")
+		if !ok {
+			continue
+		}
+		n, err := strconv.Atoi(count)
+		if err != nil {
+			continue
+		}
+		total += n
+		stacks = append(stacks, record)
+	}
+	return total, strings.Join(stacks, "\n\n")
+}
+
+// leakOneGoroutine parks a goroutine on a channel nothing else can ever
+// reference, which is exactly the shape the runtime is able to prove leaked.
+//
+//go:noinline
+func leakOneGoroutine() {
+	go func() {
+		<-make(chan struct{})
+	}()
+}
+
+// TestGoroutineLeakProfile_DetectsKnownLeak is the negative control for the
+// rest of this file: it plants a leak the runtime must be able to find. Without
+// it every other test here would still pass if detection silently stopped
+// working.
+func TestGoroutineLeakProfile_DetectsKnownLeak(t *testing.T) {
+	requireLeakProfile(t)
+
+	before, err := CountGoroutineLeaks()
+	if err != nil {
+		t.Fatalf("goroutine leak detection failed: %v", err)
+	}
+
+	leakOneGoroutine()
+
+	// The goroutine has to actually reach the blocked state before the runtime
+	// can classify it, and it is not scheduled synchronously, so retry rather
+	// than racing it on the first sample.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		after, err := CountGoroutineLeaks()
+		if err != nil {
+			t.Fatalf("goroutine leak detection failed: %v", err)
+		}
+		if after > before {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("deliberate leak went undetected: leak count stayed at %d", before)
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 }
 
@@ -217,4 +312,35 @@ func TestProxyCopy_NoGoroutineLeaks(t *testing.T) {
 	}
 
 	checkGoroutineLeaks(t)
+}
+
+// TestUnexpectedLeaks covers the profile parsing itself. If this filter ever
+// silently returned zero, every leak check in this file would pass vacuously.
+func TestUnexpectedLeaks(t *testing.T) {
+	const profile = `goroutineleak profile: total 4
+
+2 @ 0x49370a 0x41e94e
+#	0xadc675	github.com/folbricht/routedns.(*Pipeline).start+0x115	/pipeline.go:87
+
+1 @ 0x49370a 0x41e94e
+#	0xbd13a4	github.com/mosajjal/sniproxy/v2/pkg.leakOneGoroutine.func1+0x24	/goroutineleak_test.go:49
+
+1 @ 0x49370a 0x41e94e
+#	0xbd13a4	github.com/mosajjal/sniproxy/v2/pkg.handleTLS.func2+0x24	/https.go:120
+`
+
+	n, stacks := unexpectedLeaks(profile)
+	if n != 1 {
+		t.Errorf("unexpected leak count: got %d, want 1", n)
+	}
+	if !strings.Contains(stacks, "handleTLS") {
+		t.Errorf("expected the handleTLS stack to be reported, got:\n%s", stacks)
+	}
+	if strings.Contains(stacks, "Pipeline") || strings.Contains(stacks, "leakOneGoroutine") {
+		t.Errorf("known leaks should have been filtered out, got:\n%s", stacks)
+	}
+
+	if n, _ := unexpectedLeaks("goroutineleak profile: total 0\n"); n != 0 {
+		t.Errorf("empty profile should report no leaks, got %d", n)
+	}
 }

--- a/pkg/leak.go
+++ b/pkg/leak.go
@@ -1,0 +1,101 @@
+package sniproxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"runtime/pprof"
+	"time"
+
+	"github.com/rcrowley/go-metrics"
+	"github.com/rs/zerolog"
+)
+
+// GoroutineLeakProfile is the runtime/pprof profile that reports goroutines the
+// runtime has proven can never become runnable again. A goroutine counts as
+// leaked when it is blocked on a concurrency primitive (channel, sync.Mutex,
+// sync.Cond, ...) that is unreachable from any goroutine which could still
+// unblock it.
+//
+// sniproxy builds against Go 1.26, where this profile is opt-in: it only exists
+// when the binary is built with GOEXPERIMENT=goroutineleakprofile. Without that
+// the leak options degrade to a clear error rather than failing the build, so
+// an ordinary `go install` still works. The profile becomes unconditional in Go
+// 1.27.
+//
+// Detection is reachability based, so a goroutine blocked on a primitive that
+// is still reachable through a global variable, or through the locals of a
+// runnable goroutine, will not be reported even if nothing will ever signal it.
+const GoroutineLeakProfile = "goroutineleak"
+
+// GoroutineLeakExperiment is the GOEXPERIMENT value that compiles the profile
+// into the binary on Go 1.26.
+const GoroutineLeakExperiment = "goroutineleakprofile"
+
+// GoroutineLeakProfileAvailable reports whether this binary was built with
+// goroutine leak detection compiled in.
+func GoroutineLeakProfileAvailable() bool {
+	return pprof.Lookup(GoroutineLeakProfile) != nil
+}
+
+// WriteGoroutineLeakProfile writes the goroutine leak profile to w and returns
+// the number of leaked goroutines found.
+//
+// Writing is what performs the detection: the runtime runs a dedicated GC cycle
+// that marks unreachable-blocked goroutines as leaked. Reading the count on its
+// own returns whatever the previous detection run produced, which is zero if
+// there has never been one, so the count is only meaningful after a write.
+//
+// debug=0 emits the binary pprof format, debug=1 a human readable profile, and
+// debug=2 dumps every goroutine stack in the format of an unrecovered panic.
+//
+// This forces a full GC and stops the world briefly, which is why sniproxy only
+// ever calls it on demand rather than on a hot path.
+func WriteGoroutineLeakProfile(w io.Writer, debug int) (int, error) {
+	p := pprof.Lookup(GoroutineLeakProfile)
+	if p == nil {
+		return 0, fmt.Errorf("%q profile unavailable: rebuild with GOEXPERIMENT=%s (or with Go 1.27+, where it is always on)", GoroutineLeakProfile, GoroutineLeakExperiment)
+	}
+	if err := p.WriteTo(w, debug); err != nil {
+		return 0, fmt.Errorf("failed to write %q profile: %w", GoroutineLeakProfile, err)
+	}
+	return p.Count(), nil
+}
+
+// CountGoroutineLeaks runs leak detection and reports how many goroutines are
+// leaked, discarding the profile itself.
+func CountGoroutineLeaks() (int, error) {
+	return WriteGoroutineLeakProfile(io.Discard, 0)
+}
+
+// WatchGoroutineLeaks runs leak detection every interval until ctx is done,
+// publishing the result to gauge and logging a warning whenever the count is
+// above zero.
+//
+// Every check forces a full GC, so this is off by default and the interval
+// should stay coarse (minutes, not seconds) on a busy proxy.
+func WatchGoroutineLeaks(ctx context.Context, interval time.Duration, gauge metrics.Gauge, logger zerolog.Logger) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			n, err := CountGoroutineLeaks()
+			if err != nil {
+				logger.Error().Err(err).Msg("goroutine leak check failed, stopping the watcher")
+				return
+			}
+			if gauge != nil {
+				gauge.Update(int64(n))
+			}
+			if n > 0 {
+				logger.Warn().Int("leaked", n).Msgf("leaked goroutines detected; fetch /debug/pprof/%s for stacks", GoroutineLeakProfile)
+			} else {
+				logger.Debug().Msg("goroutine leak check found no leaks")
+			}
+		}
+	}
+}


### PR DESCRIPTION
Exposes the runtime's goroutine leak profile three ways, and fixes the existing leak tests — which were passing without checking anything.

Independent of #204; either can merge first.

## The test bug

`checkGoroutineLeaks` called `Profile.Count()` **before** `WriteTo()`. Writing the profile is what runs the leak-detecting GC cycle (`runtime_goroutineLeakGC`); `Count()` only reports the result of the most recent detection run, which is zero if nothing has ever triggered one. A plain `runtime.GC()` does not do it.

So every leak check was reading a stale zero and passing unconditionally.

Fixing the order immediately surfaced a real one: `routedns.(*Pipeline).start` parks a goroutine per DNS client on a channel it never closes, with no `Close`/`Stop` in the library. It is bounded at one in production since sniproxy builds its client once at startup, so it is in an explicit `knownLeaks` allowlist with that reasoning rather than papered over. I confirmed it is still present in routedns v0.1.237, so #204 does not change this.

To stop the suite going hollow again, this adds a **negative control** that plants a leak the runtime must find, and a parser test for the filter.

## The three options

| Option | What it does |
|---|---|
| `bind_pprof` | Serves `/debug/pprof/`, including `/debug/pprof/goroutineleak`. Uses its own mux rather than the `DefaultServeMux` that importing `net/http/pprof` hijacks, so the debug handlers can never appear on the metrics listener. Warns if bound to a non-loopback address. |
| `goroutine_leak_interval` | Periodic check, published as the `goroutines.leaked` gauge (`sniproxy_<public_ipv4>_goroutines_leaked`). Off by default — each check forces a full GC. |
| `--prof goroutineleak` | Writes the profile on exit. `github.com/pkg/profile` has no such mode, so it is implemented natively. |

## Build flags

CI, the Dockerfile and the release workflow now build with `GOEXPERIMENT=goroutineleakprofile,jsonv2`. Both experiments are default-on in Go 1.27; this gets the behaviour early without requiring 1.27.

Without the flags the binary still builds, the options warn **at startup** rather than failing at the first tick or at exit, and the leak tests skip. `go install` is unaffected.

`jsonv2` is included because it is free here: sniproxy only ever marshals JSON (one call site, `pkg/doh/google.go:184`), and I diffed the actual DoH response under v1 and v2 — byte-identical apart from wall-clock `Expires` values.

## Known limitation, documented in the code

Detection is reachability based and only covers concurrency primitives. Measured:

```
DETECTED      channel recv/send, unreachable channel
DETECTED      select on unreachable channels
DETECTED      sync.WaitGroup.Wait / sync.Mutex.Lock
NOT DETECTED  channel held by a global
NOT DETECTED  TCP read, peer alive but silent (io.Copy)
NOT DETECTED  time.Sleep
```

The last one matters: a goroutine parked in `io.Copy` on a socket whose peer went away is the shape that actually leaks in a TCP proxy, and this cannot see it. `go_goroutines` is what catches that. Called out in the README so nobody reads a clean leak profile as "no leaks".

Related, and deliberately **not** fixed here: `handleTLS` clears the read deadline at `pkg/https.go:81` before proxying, so a silent peer strands two `proxyCopy` goroutines plus the `handleTLS` caller. Fixing it means an idle timeout, which changes behaviour for long-lived idle connections — worth its own PR.

## Testing

- `gofmt`, `go build`, `go vet` clean; `golangci-lint run ./...` — 0 issues
- `go test -race ./...` passes with and without the experiments
- runtime smoke test: pprof endpoint returns 200, gauge exported and ticking, DNS resolves through the proxy, profile written on exit, no errors
- startup warnings verified against a binary built *without* the experiment
- new unit test for the loopback bind check (`:6060`, `[::]`, `localhost`, malformed input)

🤖 Generated with [Claude Code](https://claude.com/claude-code)