### PR TITLE
Pin release builds to Go 1.26

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,11 @@ jobs:
           GOEXPERIMENT: goroutineleakprofile,jsonv2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # must stay on the Go version whose experiments are named in the env
+          # above. This action installs the latest Go by default, and 1.27
+          # deleted the goroutineleakprofile experiment, so an unpinned build
+          # dies with "unknown GOEXPERIMENT goroutineleakprofile".
+          goversion: "1.26"
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           project_path: "./cmd/sniproxy"


### PR DESCRIPTION
All 17 platform jobs in the v2.4.0 release build failed:

```
+ go version
go: unknown GOEXPERIMENT goroutineleakprofile
```

`GOEXPERIMENT=goroutineleakprofile,jsonv2` was added to this workflow in #205 without pinning the Go version next to it. `go-release-action` installs the **latest** Go by default — now 1.27 — and 1.27 deleted the `goroutineleakprofile` experiment because the profile is always on there. `.github/workflows/go.yml` was pinned to `1.26` for precisely this reason; `release.yml` was missed.

Pins `goversion: "1.26"`, with a comment tying it to the `GOEXPERIMENT` line above so the coupling is not missed again.

The container image build was unaffected — the Dockerfile already pins `golang:1.26-alpine`.

Once this merges, v2.4.0 needs to be re-cut so the release event picks up the fixed workflow. No binaries were published, so nothing has to be un-published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)